### PR TITLE
print url/body before headers in curl debug logs

### DIFF
--- a/app/src/debug/kotlin/app/eluvio/wallet/di/DebugInterceptorsModule.kt
+++ b/app/src/debug/kotlin/app/eluvio/wallet/di/DebugInterceptorsModule.kt
@@ -1,5 +1,11 @@
 package app.eluvio.wallet.di
 
+import com.moczul.ok2curl.CommandComponent
+import com.moczul.ok2curl.CommandComponent.Body
+import com.moczul.ok2curl.CommandComponent.Curl
+import com.moczul.ok2curl.CommandComponent.Flags
+import com.moczul.ok2curl.CommandComponent.Method
+import com.moczul.ok2curl.CommandComponent.Url
 import com.moczul.ok2curl.Configuration
 import com.moczul.ok2curl.CurlInterceptor
 import com.moczul.ok2curl.Header
@@ -44,6 +50,7 @@ object DebugInterceptorsModule {
         }
         return CurlInterceptor(
             configuration = Configuration(
+                components = listOf(Curl, Flags, Method, Url, Body, CommandComponent.Header),
                 headerModifiers = listOf(headerFilter)
             ),
             logger = object : Logger {


### PR DESCRIPTION
```
curl -X GET "https://host-76-74-91-11.contentfabric.io/s/main/q/hq__bXXUgCqRsEYyPbcf9ZiCWDJiaR9ZZrJU9nCMf86NKHfW2HWgpYDosrLuKdAgR8ayNiA5fPGiRjm/files/sections/highlights/highlights-champions.jpg" -H "User-Agent:android-debug_v2.0" -H "Accept:*/*" -H "Authorization:Bearer ..."
```

```
curl -X POST "https://host-76-74-28-232.contentfabric.io/as/mw/properties/iq__3dzXSEyR9EgGVPPJJboHyGmHtt6b/sections?resolve_subsections=true" -d '["pschNM48xYFWRzJT3kQzEQGNLy"]' -H "Content-Type:application/json; charset=UTF-8" -H "User-Agent:android-debug_v2.0" -H "Accept:*/*" -H "Authorization:Bearer ........."
```